### PR TITLE
community-modules/wishlist: init

### DIFF
--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -25,8 +25,9 @@ Copy the template below and fill in each section:
 - **Proposed Approach:** High-level outline of how it could be implemented
   (optional).
 - **Related:** Links to issues, PRs, or discussions (optional).
+```
 
-### [Miscellaneous modules]
+### Miscellaneous modules
 
 - **Status:** `proposed`
 - **Author:** @xZecora
@@ -38,4 +39,3 @@ Copy the template below and fill in each section:
   namespace, although having the modules be part of the namespace that they
   extend may make more sense.
 - **Related:** Brief discussion in discord development channel.
-```

--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -1,0 +1,41 @@
+# Wishlist & Ideas
+
+This file tracks desired modules and ideas for finix community modules. If you
+are a user without the experience or knowledge to make a module, feel free to
+open a PR for this file with your desired module as a subsection.
+
+**Note:** PRs to this file should be relatively well formatted and have a good
+cause for existing. Remember that not everything needs a module. Note that some
+modules that take too much time and that have little interest may be declined or
+not worked on, it is at a contributors discretion whether to work on requested
+modules or not.
+
+## Template
+
+Copy the template below and fill in each section:
+
+```markdown
+### [Title]
+
+- **Status:** `proposed` `in-progress` `completed` `declined` (pick one).
+- **Author:** @your-handle
+- **Date:** YYYY-MM-DD
+- **Description:** A clear and concise description of the idea.
+- **Motivation:** Why is this needed? What problem does it solve?
+- **Proposed Approach:** High-level outline of how it could be implemented
+  (optional).
+- **Related:** Links to issues, PRs, or discussions (optional).
+
+### [Miscellaneous modules]
+
+- **Status:** `proposed`
+- **Author:** @xZecora
+- **Date:** 2026-06-29
+- **Description:** A category for modules that aren't programs or services, like
+  modules that extend core features and add no new programs/services.
+- **Motivation:** A way to organize a different kind of module.
+- **Proposed approach:** A new folder to store them in. Possibly a new
+  namespace, although having the modules be part of the namespace that they
+  extend may make more sense.
+- **Related:** Brief discussion in discord development channel.
+```


### PR DESCRIPTION
I basically ported the [IDEAS.md](https://github.com/finix-community/finix/blob/main/IDEAS.md) from finix, changed the idea to be more about requesting modules than implementing functionality because that doesn't really make sense for community modules. Please give feedback on if we think there is a better way to handle this kind of idea.