### PR TITLE
services/preservation: fix mount-all task

### DIFF
--- a/modules/services/preservation/README.md
+++ b/modules/services/preservation/README.md
@@ -4,8 +4,6 @@ Declarative management of non-volatile system state for finix systems using fini
 
 Inspired by [impermanence](https://github.com/nix-community/impermanence), but not a drop-in replacement. Instead of relying on shell interpreters, preservation generates a pure initrd script that runs bind mounts and symlinks via finit after, gated on the mount task of each preserved root — making it compatible with interpreter-free finix systems.
 
-Full documentation and option reference: <https://parzivale.github.io/preservation>
-
 ## Basic usage
 
 ```nix

--- a/modules/services/preservation/README.md
+++ b/modules/services/preservation/README.md
@@ -2,7 +2,7 @@
 
 Declarative management of non-volatile system state for finix systems using finit as PID 1.
 
-Inspired by [impermanence](https://github.com/nix-community/impermanence), but not a drop-in replacement. Instead of relying on shell interpreters, preservation generates a pure initrd script that runs bind mounts and symlinks via finit after `mount-all` — making it compatible with interpreter-free finix systems.
+Inspired by [impermanence](https://github.com/nix-community/impermanence), but not a drop-in replacement. Instead of relying on shell interpreters, preservation generates a pure initrd script that runs bind mounts and symlinks via finit after, gated on the mount task of each preserved root — making it compatible with interpreter-free finix systems.
 
 Full documentation and option reference: <https://parzivale.github.io/preservation>
 

--- a/modules/services/preservation/default.nix
+++ b/modules/services/preservation/default.nix
@@ -18,9 +18,9 @@ let
     ${lib.concatStringsSep "\n" allCmds}
   '';
 
-  mountConditions = lib.concatMapStringsSep "," (
-    root: "task/mount-${escapePath root}/success"
-  ) (lib.attrNames cfg.preserveAt);
+  mountConditions = lib.concatMapStringsSep "," (root: "task/mount-${escapePath root}/success") (
+    lib.attrNames cfg.preserveAt
+  );
 in
 {
   imports = [

--- a/modules/services/preservation/default.nix
+++ b/modules/services/preservation/default.nix
@@ -9,6 +9,7 @@ let
 
   inherit (import ./lib.nix { inherit lib; })
     mkFinitInitrdMountCmds
+    escapePath
     ;
 
   allCmds = lib.flatten (lib.mapAttrsToList mkFinitInitrdMountCmds cfg.preserveAt);
@@ -16,6 +17,10 @@ let
     #!/bin/sh
     ${lib.concatStringsSep "\n" allCmds}
   '';
+
+  mountConditions = lib.concatMapStringsSep "," (
+    root: "task/mount-${escapePath root}/success"
+  ) (lib.attrNames cfg.preserveAt);
 in
 {
   imports = [
@@ -31,7 +36,7 @@ in
       {
         target = "/etc/finit.d/preservation.conf";
         source = pkgs.writeText "preservation-finit-initrd.conf" ''
-          run [S] name:preservation <task/mount-all/success> preservation
+          run [S] name:preservation <${mountConditions}> preservation
         '';
       }
     ];

--- a/modules/services/preservation/lib.nix
+++ b/modules/services/preservation/lib.nix
@@ -26,6 +26,10 @@ rec {
   # concatenates a list of paths using `concatTwoPaths`
   concatPaths = builtins.foldl' concatTwoPaths "";
 
+  # simple path escape into a name safe for use as a finit stanza name and conditions
+  escapePath =
+    s: if s == "/" then "root" else lib.replaceStrings [ "/" ] [ "-" ] (lib.removePrefix "/" s);
+
   # get the parent directory of an absolute path
   parentDirectory =
     path:


### PR DESCRIPTION
issue: fallout from https://github.com/finix-community/finix/pull/137 which removed the mount-all task and caused hanging and binds never being created.

fix: gate the run stanza on the mount task of each preserveAt root instead of <task/mount-<escaped>/success, comma-ANDed for multiple roots, replicating finix's utils.escapedPath locally so name match. also update README to match the change

tested with tmpfs root / impermanence finix host