### PR TITLE
modules/services/preservation: couple escapePath to finix

### DIFF
--- a/modules/services/preservation/default.nix
+++ b/modules/services/preservation/default.nix
@@ -2,6 +2,7 @@
   config,
   pkgs,
   lib,
+  utils,
   ...
 }:
 let
@@ -9,8 +10,9 @@ let
 
   inherit (import ./lib.nix { inherit lib; })
     mkFinitInitrdMountCmds
-    escapePath
     ;
+
+  inherit (utils) escapePath;
 
   allCmds = lib.flatten (lib.mapAttrsToList mkFinitInitrdMountCmds cfg.preserveAt);
   script = pkgs.writeScript "preservation-initrd" ''

--- a/modules/services/preservation/lib.nix
+++ b/modules/services/preservation/lib.nix
@@ -26,10 +26,6 @@ rec {
   # concatenates a list of paths using `concatTwoPaths`
   concatPaths = builtins.foldl' concatTwoPaths "";
 
-  # simple path escape into a name safe for use as a finit stanza name and conditions
-  escapePath =
-    s: if s == "/" then "root" else lib.replaceStrings [ "/" ] [ "-" ] (lib.removePrefix "/" s);
-
   # get the parent directory of an absolute path
   parentDirectory =
     path:


### PR DESCRIPTION
issue: https://github.com/finix-community/finix/pull/164 may cause fallout with this module. 

fix: couple the escapePath to the on in finix so no conflict arises. 

tested on impermanent host, results in byte identical derivation being build 