### PR TITLE
programs/gamescope: init

### DIFF
--- a/modules/programs/gamescope/default.nix
+++ b/modules/programs/gamescope/default.nix
@@ -1,0 +1,82 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.gamescope;
+
+  gamescope =
+    let
+      wrapperArgs =
+        lib.optional (cfg.args != [ ]) ''--add-flags "${toString cfg.args}"''
+        ++ builtins.attrValues (builtins.mapAttrs (var: val: "--set-default ${var} ${val}") cfg.env);
+    in
+    pkgs.runCommand "gamescope" { nativeBuildInputs = [ pkgs.makeBinaryWrapper ]; } ''
+      mkdir -p $out/bin
+      makeWrapper ${cfg.package}/bin/gamescope $out/bin/gamescope --inherit-argv0 \
+        ${toString wrapperArgs}
+      ln -s ${cfg.package}/bin/gamescopectl $out/bin/gamescopectl
+    '';
+in
+{
+  options.programs.gamescope = {
+    enable = lib.mkEnableOption "gamescope, the SteamOS session compositing window manager";
+
+    package = lib.mkPackageOption pkgs "gamescope" { };
+
+    capSysNice = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Add cap_sys_nice capability to the GameScope
+        binary so that it may renice itself.
+      '';
+    };
+
+    args = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "--rt"
+        "--prefer-vk-device 8086:9bc4"
+      ];
+      description = ''
+        Arguments passed to GameScope on startup.
+      '';
+    };
+
+    env = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = lib.literalExpression ''
+        # for Prime render offload on Nvidia laptops.
+        # Also requires `hardware.nvidia.prime.offload.enable`.
+        {
+          __NV_PRIME_RENDER_OFFLOAD = "1";
+          __VK_LAYER_NV_optimus = "NVIDIA_only";
+          __GLX_VENDOR_LIBRARY_NAME = "nvidia";
+        }
+      '';
+      description = ''
+        Default environment variables available to the GameScope process, overridable at runtime.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    security.wrappers = lib.mkIf cfg.capSysNice {
+      gamescope = {
+        owner = "root";
+        group = "root";
+        source = "${gamescope}/bin/gamescope";
+        capabilities = "cap_sys_nice+pie";
+      };
+    };
+
+    environment.systemPackages = lib.mkIf (!cfg.capSysNice) [ gamescope ];
+  };
+
+  meta.maintainers = [ ];
+}

--- a/modules/programs/steam/default.nix
+++ b/modules/programs/steam/default.nix
@@ -10,6 +10,29 @@ let
 
   extraCompatPaths = lib.makeSearchPathOutput "steamcompattool" "" cfg.extraCompatPackages;
 
+  steam-gamescope =
+    let
+      exports = builtins.attrValues (
+        builtins.mapAttrs (n: v: "export ${n}=${v}") cfg.gamescopeSession.env
+      );
+    in
+    pkgs.writeShellScriptBin "steam-gamescope" ''
+      ${builtins.concatStringsSep "\n" exports}
+      gamescope --steam ${toString cfg.gamescopeSession.args} -- steam ${toString cfg.gamescopeSession.steamArgs}
+    '';
+
+  gamescopeSessionFile =
+    (pkgs.writeTextDir "share/wayland-sessions/steam.desktop" ''
+      [Desktop Entry]
+      Name=Steam
+      Comment=A digital distribution platform
+      Exec="${pkgs.dbus}/bin/dbus-run-session -- ${steam-gamescope}/bin/steam-gamescope"
+      Type=Application
+    '').overrideAttrs
+      (_: {
+        passthru.providedSessions = [ "steam" ];
+      });
+
 in
 {
   options.programs.steam = {
@@ -111,6 +134,42 @@ in
       '';
     };
 
+    gamescopeSession = lib.mkOption {
+      description = "Run a GameScope driven Steam session from your display-manager";
+      default = { };
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkEnableOption "GameScope Session";
+          args = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            description = ''
+              Arguments to be passed to GameScope for the session.
+            '';
+          };
+
+          env = lib.mkOption {
+            type = lib.types.attrsOf lib.types.str;
+            default = { };
+            description = ''
+              Environmental variables to be passed to GameScope for the session.
+            '';
+          };
+
+          steamArgs = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [
+              "-tenfoot"
+              "-pipewire-dmabuf"
+            ];
+            description = ''
+              Arguments to be passed to Steam for the session.
+            '';
+          };
+        };
+      };
+    };
+
     extest.enable = lib.mkEnableOption ''
       Load the extest library into Steam, to translate X11 input events to
       uinput events (e.g. for using Steam Input on Wayland)
@@ -132,11 +191,16 @@ in
     };
 
     programs.steam.extraPackages = cfg.fontPackages;
+    programs.gamescope.enable = lib.mkDefault cfg.gamescopeSession.enable;
+
+    services.dbus.enable = true;
 
     environment.systemPackages = [
+      (lib.hiPrio gamescopeSessionFile)
       cfg.package
       cfg.package.run
     ]
+    ++ lib.optional cfg.gamescopeSession.enable steam-gamescope
     ++ lib.optional cfg.protontricks.enable (
       cfg.protontricks.package.override { inherit extraCompatPaths; }
     );


### PR DESCRIPTION
Adds `programs.gamescope` and an extra option to `programs.steam` for running a gamescope based wayland session.