### PR TITLE
Adds the NH and efistubmgr modules

### DIFF
--- a/modules/programs/efistubmgr/default.nix
+++ b/modules/programs/efistubmgr/default.nix
@@ -1,0 +1,241 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.programs.efistubmgr;
+  ESP_REL_DIR = "${lib.removePrefix "/" (lib.removePrefix cfg.efiMountPoint cfg.bootDir)}";
+  efistubHook = pkgs.writeShellScript "efistub-install" ''
+      set -euo pipefail
+
+      # ── Paths & metadata ──────────────────────────────────────────────────────
+
+      EFISTUBMGR="${cfg.package}/bin/efistubmgr"
+
+      TIMESTAMP=$(${pkgs.coreutils}/bin/date +%s)
+      KERNEL_PATH="${cfg.bootDir}/kernel-$TIMESTAMP.efi"
+      INITRD_PATH="${cfg.bootDir}/initrd-$TIMESTAMP"
+
+      # ── Helpers ───────────────────────────────────────────────────────────────
+
+      get_rev() {
+        local target="$1"
+        local path="$2"
+        local link
+
+        for link in /nix/var/nix/profiles/system-*-link; do
+          [ -e "$link" ] || continue
+
+          case "$(readlink "$link")" in
+            "$target"|"$path")
+              printf '%s\n' "$link" |
+                ${pkgs.gnugrep}/bin/grep -oE 'system-[0-9]+-link' |
+                ${pkgs.gnugrep}/bin/grep -oE '[0-9]+' |
+                ${pkgs.gawk}/bin/awk '{print "rev. " $1}'
+              return
+              ;;
+          esac
+        done
+      }
+
+      is_kept_timestamp() {
+        local needle="$1"
+
+        for ts in "''${KEEP_TIMESTAMPS[@]}"; do
+          [ "$ts" = "$needle" ] && return 0
+        done
+
+        return 1
+      }
+
+      is_seen_timestamp() {
+        local needle="$1"
+
+        for ts in "''${ORPHAN_TIMESTAMPS[@]}"; do
+          [ "$ts" = "$needle" ] && return 0
+        done
+
+        return 1
+      }
+
+      # ── Validate & read bootspec ──────────────────────────────────────────────
+
+      [ -r ${cfg.bootSpec} ] ||
+        { echo "ERROR: boot.json not found at ${cfg.bootSpec}"; exit 1; }
+
+      KERNEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".kernel' "${cfg.bootSpec}")
+      INITRD=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".initrd' "${cfg.bootSpec}")
+      INIT=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".init' "${cfg.bootSpec}")
+      PARAMS=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".kernelParams | join(" ")' "${cfg.bootSpec}")
+      LABEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".label // empty' "${cfg.bootSpec}")
+      TOPLEVEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".toplevel // empty' "${cfg.bootSpec}")
+
+      [ -z "$LABEL" ] || [ "$LABEL" = "null" ] && LABEL="Finix"
+      [ -z "$TOPLEVEL" ] && TOPLEVEL="$1"
+
+      REV=$(get_rev "$TOPLEVEL" "$1")
+      DESCRIPTION="${cfg.bootEntry}"
+
+      # ── Install kernel & initrd ───────────────────────────────────────────────
+
+      mkdir -p ${cfg.bootDir}
+
+      echo "==> Installing kernel and initrd (timestamp: $TIMESTAMP)"
+      install -m 0644 "$KERNEL" "$KERNEL_PATH"
+      install -m 0644 "$INITRD" "$INITRD_PATH"
+
+      # ── Secure Boot ───────────────────────────────────────────────────────────
+
+      if [ "${lib.boolToString cfg.secureBoot.enable}" = "true" ]; then
+        if [ -d ${cfg.secureBoot.keyLocation} ]; then
+          echo "==> sbctl: signing kernel"
+          ${cfg.secureBoot.sbctl}/bin/sbctl sign "$KERNEL_PATH" || \
+            echo "WARNING: sbctl signing failed, but continuing (Secure Boot may not work)"
+        fi
+      fi
+
+      # ── Create NVRAM entry ────────────────────────────────────────────────────
+
+      echo "==> Creating new primary entry: $DESCRIPTION (timestamp $TIMESTAMP)"
+      ESP_REL_DIR_WIN=$(${pkgs.coreutils}/bin/tr '/' '\\' <<< "${ESP_REL_DIR}")
+      ESP_KERNEL_PATH="\\''${ESP_REL_DIR_WIN}\\kernel-$TIMESTAMP.efi"
+      ESP_INITRD_PATH="\\''${ESP_REL_DIR_WIN}\\initrd-$TIMESTAMP"
+      NEW_ID=$("$EFISTUBMGR" create "${cfg.efiMountPoint}" \
+        '\EFI\finix\kernel-'"$TIMESTAMP"'.efi' \
+        "$DESCRIPTION" \
+        "initrd=$ESP_INITRD_PATH init=$INIT $PARAMS" \
+        --timestamp "$TIMESTAMP")
+
+      echo "==> Created Boot$NEW_ID"
+
+      # ── Keep newest generations ───────────────────────────────────────────────
+
+      mapfile -t GENERATIONS < <("$EFISTUBMGR" list)
+      echo "==> ''${#GENERATIONS[@]} finix generation(s) in NVRAM"
+
+      KEEP_TIMESTAMPS=()
+      for line in "''${GENERATIONS[@]:0:${toString cfg.maxGenerations}}"; do
+        KEEP_TIMESTAMPS+=(
+          "$(${pkgs.gawk}/bin/awk '{print $2}' <<<"$line")"
+        )
+      done
+
+      declare -A PRUNE_IDS
+
+      if [ "''${#GENERATIONS[@]}" -gt "${toString cfg.maxGenerations}" ]; then
+        for line in "''${GENERATIONS[@]:${toString cfg.maxGenerations}}"; do
+          id=$(${pkgs.gawk}/bin/awk '{print $1}' <<<"$line")
+          ts=$(${pkgs.gawk}/bin/awk '{print $2}' <<<"$line")
+
+          "$EFISTUBMGR" delete "$id"
+          PRUNE_IDS["$ts"]="$id"
+        done
+      fi
+
+      # ── Remove orphaned ESP files ─────────────────────────────────────────────
+
+      ORPHAN_TIMESTAMPS=()
+
+      for f in "${cfg.bootDir}"/kernel-*.efi "${cfg.bootDir}"/initrd-*; do
+        [ -e "$f" ] || continue
+
+        base=$(basename "$f")
+        file_ts="''${base#*-}"
+        file_ts="''${file_ts%.efi}"
+
+        if ! is_kept_timestamp "$file_ts" &&
+           ! is_seen_timestamp "$file_ts"; then
+          ORPHAN_TIMESTAMPS+=("$file_ts")
+        fi
+      done
+
+      for ts in "''${ORPHAN_TIMESTAMPS[@]}"; do
+        if [ -n "''${PRUNE_IDS[$ts]:-}" ]; then
+          echo "==> Removing orphaned ESP files kernel-$ts.efi + initrd-$ts" \
+            "(ts $ts, removed matching Boot''${PRUNE_IDS[$ts]} NVRAM entry)"
+        else
+          echo "==> Removing orphaned ESP files kernel-$ts.efi + initrd-$ts" \
+            "(ts $ts, no matching NVRAM entry)"
+        fi
+
+        rm -f "${cfg.bootDir}/kernel-$ts.efi" "${cfg.bootDir}/initrd-$ts"
+      done
+
+      echo "==> EFISTUB setup complete"
+    '';
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    Z4il
+  ];
+  options.programs.efistubmgr = {
+    enable = lib.mkEnableOption "Minimal EFISTUB manager written in Rust.";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./package.nix { };
+      defaultText = lib.literalExpression "pkgs.callPackage ./package.nix {}";
+      description = ''
+        The package to use for efistubmgr.
+      '';
+    };
+    efiMountPoint = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.boot.loader.efi.efiSysMountPoint}";
+      description = ''
+        Where the EFI System Partition is mounted.
+      '';
+    };
+    maxGenerations = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 3;
+      description = ''
+        Number of generations (positive and >0) to show in UEFI boot picker/to keep in NVRAM.
+      '';
+    };
+    secureBoot = {
+      enable = lib.mkEnableOption "Whether to enable secure boot or not.";
+      keyLocation = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/sbctl/keys";
+        description = ''
+          Location of the keys used for secureboot signing, bring your own.
+        '';
+      };
+      sbctl = lib.mkPackageOption pkgs "sbctl" { };
+    };
+    bootDir = lib.mkOption {
+      type = lib.types.str;
+      default = "${cfg.efiMountPoint}/EFI/finix";
+      description = ''
+        Where to save the kerenl stubs and initrd
+      '';
+    };
+    bootEntry = lib.mkOption {
+      type = lib.types.str;
+      default = ''$LABEL''${REV:+ $REV} * $(${pkgs.coreutils}/bin/date -d "@$TIMESTAMP" '+%Y-%m-%d %H:%M:%S %Z')'';
+      description = "How each generation appears in the UEFI boot picker, REV and LABEL are provided as is in the install script. Non ASCII characters may stop it from appearing in the Boot Options";
+    };
+    
+    bootSpec = lib.mkOption {
+      type = lib.types.str;
+      default = "$1/boot.json";
+      description = ''
+        Path to a boot specification, best to leave as default unless you know what you are doing
+      '';
+    };
+  };
+  config = {
+    environment = lib.mkIf cfg.enable {
+      systemPackages = [
+        cfg.package
+        pkgs.jq
+      ];
+    };
+    boot.loader.script = {
+      enable = true;
+      installHook = efistubHook;
+    };
+  };
+}

--- a/modules/programs/efistubmgr/default.nix
+++ b/modules/programs/efistubmgr/default.nix
@@ -8,163 +8,163 @@ let
   cfg = config.programs.efistubmgr;
   ESP_REL_DIR = "${lib.removePrefix "/" (lib.removePrefix cfg.efiMountPoint cfg.bootDir)}";
   efistubHook = pkgs.writeShellScript "efistub-install" ''
-      set -euo pipefail
+    set -euo pipefail
 
-      # ── Paths & metadata ──────────────────────────────────────────────────────
+    # ── Paths & metadata ──────────────────────────────────────────────────────
 
-      EFISTUBMGR="${cfg.package}/bin/efistubmgr"
+    EFISTUBMGR="${cfg.package}/bin/efistubmgr"
 
-      TIMESTAMP=$(${pkgs.coreutils}/bin/date +%s)
-      KERNEL_PATH="${cfg.bootDir}/kernel-$TIMESTAMP.efi"
-      INITRD_PATH="${cfg.bootDir}/initrd-$TIMESTAMP"
+    TIMESTAMP=$(${pkgs.coreutils}/bin/date +%s)
+    KERNEL_PATH="${cfg.bootDir}/kernel-$TIMESTAMP.efi"
+    INITRD_PATH="${cfg.bootDir}/initrd-$TIMESTAMP"
 
-      # ── Helpers ───────────────────────────────────────────────────────────────
+    # ── Helpers ───────────────────────────────────────────────────────────────
 
-      get_rev() {
-        local target="$1"
-        local path="$2"
-        local link
+    get_rev() {
+      local target="$1"
+      local path="$2"
+      local link
 
-        for link in /nix/var/nix/profiles/system-*-link; do
-          [ -e "$link" ] || continue
+      for link in /nix/var/nix/profiles/system-*-link; do
+        [ -e "$link" ] || continue
 
-          case "$(readlink "$link")" in
-            "$target"|"$path")
-              printf '%s\n' "$link" |
-                ${pkgs.gnugrep}/bin/grep -oE 'system-[0-9]+-link' |
-                ${pkgs.gnugrep}/bin/grep -oE '[0-9]+' |
-                ${pkgs.gawk}/bin/awk '{print "rev. " $1}'
-              return
-              ;;
-          esac
-        done
-      }
+        case "$(readlink "$link")" in
+          "$target"|"$path")
+            printf '%s\n' "$link" |
+              ${pkgs.gnugrep}/bin/grep -oE 'system-[0-9]+-link' |
+              ${pkgs.gnugrep}/bin/grep -oE '[0-9]+' |
+              ${pkgs.gawk}/bin/awk '{print "rev. " $1}'
+            return
+            ;;
+        esac
+      done
+    }
 
-      is_kept_timestamp() {
-        local needle="$1"
+    is_kept_timestamp() {
+      local needle="$1"
 
-        for ts in "''${KEEP_TIMESTAMPS[@]}"; do
-          [ "$ts" = "$needle" ] && return 0
-        done
-
-        return 1
-      }
-
-      is_seen_timestamp() {
-        local needle="$1"
-
-        for ts in "''${ORPHAN_TIMESTAMPS[@]}"; do
-          [ "$ts" = "$needle" ] && return 0
-        done
-
-        return 1
-      }
-
-      # ── Validate & read bootspec ──────────────────────────────────────────────
-
-      [ -r ${cfg.bootSpec} ] ||
-        { echo "ERROR: boot.json not found at ${cfg.bootSpec}"; exit 1; }
-
-      KERNEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".kernel' "${cfg.bootSpec}")
-      INITRD=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".initrd' "${cfg.bootSpec}")
-      INIT=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".init' "${cfg.bootSpec}")
-      PARAMS=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".kernelParams | join(" ")' "${cfg.bootSpec}")
-      LABEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".label // empty' "${cfg.bootSpec}")
-      TOPLEVEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".toplevel // empty' "${cfg.bootSpec}")
-
-      [ -z "$LABEL" ] || [ "$LABEL" = "null" ] && LABEL="Finix"
-      [ -z "$TOPLEVEL" ] && TOPLEVEL="$1"
-
-      REV=$(get_rev "$TOPLEVEL" "$1")
-      DESCRIPTION="${cfg.bootEntry}"
-
-      # ── Install kernel & initrd ───────────────────────────────────────────────
-
-      mkdir -p ${cfg.bootDir}
-
-      echo "==> Installing kernel and initrd (timestamp: $TIMESTAMP)"
-      install -m 0644 "$KERNEL" "$KERNEL_PATH"
-      install -m 0644 "$INITRD" "$INITRD_PATH"
-
-      # ── Secure Boot ───────────────────────────────────────────────────────────
-
-      if [ "${lib.boolToString cfg.secureBoot.enable}" = "true" ]; then
-        if [ -d ${cfg.secureBoot.keyLocation} ]; then
-          echo "==> sbctl: signing kernel"
-          ${cfg.secureBoot.sbctl}/bin/sbctl sign "$KERNEL_PATH" || \
-            echo "WARNING: sbctl signing failed, but continuing (Secure Boot may not work)"
-        fi
-      fi
-
-      # ── Create NVRAM entry ────────────────────────────────────────────────────
-
-      echo "==> Creating new primary entry: $DESCRIPTION (timestamp $TIMESTAMP)"
-      ESP_REL_DIR_WIN=$(${pkgs.coreutils}/bin/tr '/' '\\' <<< "${ESP_REL_DIR}")
-      ESP_KERNEL_PATH="\\''${ESP_REL_DIR_WIN}\\kernel-$TIMESTAMP.efi"
-      ESP_INITRD_PATH="\\''${ESP_REL_DIR_WIN}\\initrd-$TIMESTAMP"
-      NEW_ID=$("$EFISTUBMGR" create "${cfg.efiMountPoint}" \
-        '\EFI\finix\kernel-'"$TIMESTAMP"'.efi' \
-        "$DESCRIPTION" \
-        "initrd=$ESP_INITRD_PATH init=$INIT $PARAMS" \
-        --timestamp "$TIMESTAMP")
-
-      echo "==> Created Boot$NEW_ID"
-
-      # ── Keep newest generations ───────────────────────────────────────────────
-
-      mapfile -t GENERATIONS < <("$EFISTUBMGR" list)
-      echo "==> ''${#GENERATIONS[@]} finix generation(s) in NVRAM"
-
-      KEEP_TIMESTAMPS=()
-      for line in "''${GENERATIONS[@]:0:${toString cfg.maxGenerations}}"; do
-        KEEP_TIMESTAMPS+=(
-          "$(${pkgs.gawk}/bin/awk '{print $2}' <<<"$line")"
-        )
+      for ts in "''${KEEP_TIMESTAMPS[@]}"; do
+        [ "$ts" = "$needle" ] && return 0
       done
 
-      declare -A PRUNE_IDS
+      return 1
+    }
 
-      if [ "''${#GENERATIONS[@]}" -gt "${toString cfg.maxGenerations}" ]; then
-        for line in "''${GENERATIONS[@]:${toString cfg.maxGenerations}}"; do
-          id=$(${pkgs.gawk}/bin/awk '{print $1}' <<<"$line")
-          ts=$(${pkgs.gawk}/bin/awk '{print $2}' <<<"$line")
-
-          "$EFISTUBMGR" delete "$id"
-          PRUNE_IDS["$ts"]="$id"
-        done
-      fi
-
-      # ── Remove orphaned ESP files ─────────────────────────────────────────────
-
-      ORPHAN_TIMESTAMPS=()
-
-      for f in "${cfg.bootDir}"/kernel-*.efi "${cfg.bootDir}"/initrd-*; do
-        [ -e "$f" ] || continue
-
-        base=$(basename "$f")
-        file_ts="''${base#*-}"
-        file_ts="''${file_ts%.efi}"
-
-        if ! is_kept_timestamp "$file_ts" &&
-           ! is_seen_timestamp "$file_ts"; then
-          ORPHAN_TIMESTAMPS+=("$file_ts")
-        fi
-      done
+    is_seen_timestamp() {
+      local needle="$1"
 
       for ts in "''${ORPHAN_TIMESTAMPS[@]}"; do
-        if [ -n "''${PRUNE_IDS[$ts]:-}" ]; then
-          echo "==> Removing orphaned ESP files kernel-$ts.efi + initrd-$ts" \
-            "(ts $ts, removed matching Boot''${PRUNE_IDS[$ts]} NVRAM entry)"
-        else
-          echo "==> Removing orphaned ESP files kernel-$ts.efi + initrd-$ts" \
-            "(ts $ts, no matching NVRAM entry)"
-        fi
-
-        rm -f "${cfg.bootDir}/kernel-$ts.efi" "${cfg.bootDir}/initrd-$ts"
+        [ "$ts" = "$needle" ] && return 0
       done
 
-      echo "==> EFISTUB setup complete"
-    '';
+      return 1
+    }
+
+    # ── Validate & read bootspec ──────────────────────────────────────────────
+
+    [ -r ${cfg.bootSpec} ] ||
+      { echo "ERROR: boot.json not found at ${cfg.bootSpec}"; exit 1; }
+
+    KERNEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".kernel' "${cfg.bootSpec}")
+    INITRD=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".initrd' "${cfg.bootSpec}")
+    INIT=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".init' "${cfg.bootSpec}")
+    PARAMS=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".kernelParams | join(" ")' "${cfg.bootSpec}")
+    LABEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".label // empty' "${cfg.bootSpec}")
+    TOPLEVEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".toplevel // empty' "${cfg.bootSpec}")
+
+    [ -z "$LABEL" ] || [ "$LABEL" = "null" ] && LABEL="Finix"
+    [ -z "$TOPLEVEL" ] && TOPLEVEL="$1"
+
+    REV=$(get_rev "$TOPLEVEL" "$1")
+    DESCRIPTION="${cfg.bootEntry}"
+
+    # ── Install kernel & initrd ───────────────────────────────────────────────
+
+    mkdir -p ${cfg.bootDir}
+
+    echo "==> Installing kernel and initrd (timestamp: $TIMESTAMP)"
+    install -m 0644 "$KERNEL" "$KERNEL_PATH"
+    install -m 0644 "$INITRD" "$INITRD_PATH"
+
+    # ── Secure Boot ───────────────────────────────────────────────────────────
+
+    if [ "${lib.boolToString cfg.secureBoot.enable}" = "true" ]; then
+      if [ -d ${cfg.secureBoot.keyLocation} ]; then
+        echo "==> sbctl: signing kernel"
+        ${cfg.secureBoot.sbctl}/bin/sbctl sign "$KERNEL_PATH" || \
+          echo "WARNING: sbctl signing failed, but continuing (Secure Boot may not work)"
+      fi
+    fi
+
+    # ── Create NVRAM entry ────────────────────────────────────────────────────
+
+    echo "==> Creating new primary entry: $DESCRIPTION (timestamp $TIMESTAMP)"
+    ESP_REL_DIR_WIN=$(${pkgs.coreutils}/bin/tr '/' '\\' <<< "${ESP_REL_DIR}")
+    ESP_KERNEL_PATH="\\''${ESP_REL_DIR_WIN}\\kernel-$TIMESTAMP.efi"
+    ESP_INITRD_PATH="\\''${ESP_REL_DIR_WIN}\\initrd-$TIMESTAMP"
+    NEW_ID=$("$EFISTUBMGR" create "${cfg.efiMountPoint}" \
+      '\EFI\finix\kernel-'"$TIMESTAMP"'.efi' \
+      "$DESCRIPTION" \
+      "initrd=$ESP_INITRD_PATH init=$INIT $PARAMS" \
+      --timestamp "$TIMESTAMP")
+
+    echo "==> Created Boot$NEW_ID"
+
+    # ── Keep newest generations ───────────────────────────────────────────────
+
+    mapfile -t GENERATIONS < <("$EFISTUBMGR" list)
+    echo "==> ''${#GENERATIONS[@]} finix generation(s) in NVRAM"
+
+    KEEP_TIMESTAMPS=()
+    for line in "''${GENERATIONS[@]:0:${toString cfg.maxGenerations}}"; do
+      KEEP_TIMESTAMPS+=(
+        "$(${pkgs.gawk}/bin/awk '{print $2}' <<<"$line")"
+      )
+    done
+
+    declare -A PRUNE_IDS
+
+    if [ "''${#GENERATIONS[@]}" -gt "${toString cfg.maxGenerations}" ]; then
+      for line in "''${GENERATIONS[@]:${toString cfg.maxGenerations}}"; do
+        id=$(${pkgs.gawk}/bin/awk '{print $1}' <<<"$line")
+        ts=$(${pkgs.gawk}/bin/awk '{print $2}' <<<"$line")
+
+        "$EFISTUBMGR" delete "$id"
+        PRUNE_IDS["$ts"]="$id"
+      done
+    fi
+
+    # ── Remove orphaned ESP files ─────────────────────────────────────────────
+
+    ORPHAN_TIMESTAMPS=()
+
+    for f in "${cfg.bootDir}"/kernel-*.efi "${cfg.bootDir}"/initrd-*; do
+      [ -e "$f" ] || continue
+
+      base=$(basename "$f")
+      file_ts="''${base#*-}"
+      file_ts="''${file_ts%.efi}"
+
+      if ! is_kept_timestamp "$file_ts" &&
+         ! is_seen_timestamp "$file_ts"; then
+        ORPHAN_TIMESTAMPS+=("$file_ts")
+      fi
+    done
+
+    for ts in "''${ORPHAN_TIMESTAMPS[@]}"; do
+      if [ -n "''${PRUNE_IDS[$ts]:-}" ]; then
+        echo "==> Removing orphaned ESP files kernel-$ts.efi + initrd-$ts" \
+          "(ts $ts, removed matching Boot''${PRUNE_IDS[$ts]} NVRAM entry)"
+      else
+        echo "==> Removing orphaned ESP files kernel-$ts.efi + initrd-$ts" \
+          "(ts $ts, no matching NVRAM entry)"
+      fi
+
+      rm -f "${cfg.bootDir}/kernel-$ts.efi" "${cfg.bootDir}/initrd-$ts"
+    done
+
+    echo "==> EFISTUB setup complete"
+  '';
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -217,7 +217,7 @@ in
       default = ''$LABEL''${REV:+ $REV} * $(${pkgs.coreutils}/bin/date -d "@$TIMESTAMP" '+%Y-%m-%d %H:%M:%S %Z')'';
       description = "How each generation appears in the UEFI boot picker, REV and LABEL are provided as is in the install script. Non ASCII characters may stop it from appearing in the Boot Options";
     };
-    
+
     bootSpec = lib.mkOption {
       type = lib.types.str;
       default = "$1/boot.json";

--- a/modules/programs/efistubmgr/package.nix
+++ b/modules/programs/efistubmgr/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "efistubmgr";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "FixeQD";
+    repo = "${finalAttrs.pname}";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-37x8XovrC5uijGuCfS8zmSqR8ltSHVgedWmTmTC62JM=";
+  };
+
+  cargoHash = "sha256-uTd5K8wvtoplZfc+328bquTyAIdcHCVYF8ljgtcx2No=";
+
+  meta = {
+    description = "Minimal EFISTUB manager written in Rust.";
+    homepage = "https://github.com/${finalAttrs.src.owner}/${finalAttrs.pname}/";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ "z4il" ];
+  };
+})

--- a/modules/programs/nh/default.nix
+++ b/modules/programs/nh/default.nix
@@ -1,0 +1,82 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.nh;
+in
+{
+  options.programs.nh = {
+    enable = lib.mkEnableOption "nh, yet another Nix CLI helper";
+
+    package = lib.mkPackageOption pkgs "nh" { };
+
+    flake = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        The string that will be used for the `NH_FLAKE` environment variable.
+
+        `NH_FLAKE` is used by nh as the default flake for performing actions, such as
+        `nh os switch`. This behaviour can be overriden per-command with environment
+        variables that will take priority.
+
+        - `NH_OS_FLAKE`: will take priority for `nh os` commands.
+        - `NH_HOME_FLAKE`: will take priority for `nh home` commands.
+        - `NH_DARWIN_FLAKE`: will take priority for `nh darwin` commands.
+
+        The formerly valid `FLAKE` is now deprecated by nh, and will cause hard errors
+        in future releases if `NH_FLAKE` is not set.
+      '';
+    };
+
+    clean = {
+      enable = lib.mkEnableOption "periodic garbage collection with nh clean all";
+
+      dates = lib.mkOption {
+        type = lib.types.singleLineStr;
+        default = "weekly";
+        description = ''
+          How often cleanup is performed. Passed to providers.scheduler
+        '';
+      };
+
+      extraArgs = lib.mkOption {
+        type = lib.types.singleLineStr;
+        default = "";
+        example = "--keep 5 --keep-since 3d";
+        description = ''
+          Options given to nh clean when the service is run automatically.
+
+          See `nh clean all --help` for more information.
+        '';
+      };
+    };
+  };
+
+  config = {
+    assertions = [
+      {
+        assertion = (cfg.flake != null) -> !(lib.hasSuffix ".nix" cfg.flake);
+        message = "nh.flake must be a directory, not a nix file";
+      }
+    ];
+
+    environment = lib.mkIf cfg.enable {
+      systemPackages = [ cfg.package ];
+      variables = lib.mkIf (cfg.flake != null) {
+        NH_FLAKE = cfg.flake;
+      };
+    };
+
+    providers.scheduler = {
+      backend = lib.mkDefault "cron";
+      tasks.nh-clean = {
+        command = "exec ${lib.getExe cfg.package} clean all ${cfg.clean.extraArgs}";
+        interval = cfg.clean.dates;  
+      };
+    };
+  };
+}

--- a/modules/programs/nh/default.nix
+++ b/modules/programs/nh/default.nix
@@ -1,88 +1,241 @@
 {
-  config,
-  lib,
   pkgs,
+  lib,
+  config,
   ...
 }:
 let
-  cfg = config.programs.nh;
+  cfg = config.programs.efistubmgr;
+  ESP_REL_DIR = "${lib.removePrefix "/" (lib.removePrefix cfg.efiMountPoint cfg.bootDir)}";
+  efistubHook = pkgs.writeShellScript "efistub-install" ''
+    set -euo pipefail
+
+    # ── Paths & metadata ──────────────────────────────────────────────────────
+
+    EFISTUBMGR="${cfg.package}/bin/efistubmgr"
+
+    TIMESTAMP=$(${pkgs.coreutils}/bin/date +%s)
+    KERNEL_PATH="${cfg.bootDir}/kernel-$TIMESTAMP.efi"
+    INITRD_PATH="${cfg.bootDir}/initrd-$TIMESTAMP"
+
+    # ── Helpers ───────────────────────────────────────────────────────────────
+
+    get_rev() {
+      local target="$1"
+      local path="$2"
+      local link
+
+      for link in /nix/var/nix/profiles/system-*-link; do
+        [ -e "$link" ] || continue
+
+        case "$(readlink "$link")" in
+          "$target"|"$path")
+            printf '%s\n' "$link" |
+              ${pkgs.gnugrep}/bin/grep -oE 'system-[0-9]+-link' |
+              ${pkgs.gnugrep}/bin/grep -oE '[0-9]+' |
+              ${pkgs.gawk}/bin/awk '{print "rev. " $1}'
+            return
+            ;;
+        esac
+      done
+    }
+
+    is_kept_timestamp() {
+      local needle="$1"
+
+      for ts in "''${KEEP_TIMESTAMPS[@]}"; do
+        [ "$ts" = "$needle" ] && return 0
+      done
+
+      return 1
+    }
+
+    is_seen_timestamp() {
+      local needle="$1"
+
+      for ts in "''${ORPHAN_TIMESTAMPS[@]}"; do
+        [ "$ts" = "$needle" ] && return 0
+      done
+
+      return 1
+    }
+
+    # ── Validate & read bootspec ──────────────────────────────────────────────
+
+    [ -r ${cfg.bootSpec} ] ||
+      { echo "ERROR: boot.json not found at ${cfg.bootSpec}"; exit 1; }
+
+    KERNEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".kernel' "${cfg.bootSpec}")
+    INITRD=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".initrd' "${cfg.bootSpec}")
+    INIT=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".init' "${cfg.bootSpec}")
+    PARAMS=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".kernelParams | join(" ")' "${cfg.bootSpec}")
+    LABEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".label // empty' "${cfg.bootSpec}")
+    TOPLEVEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".toplevel // empty' "${cfg.bootSpec}")
+
+    [ -z "$LABEL" ] || [ "$LABEL" = "null" ] && LABEL="Finix"
+    [ -z "$TOPLEVEL" ] && TOPLEVEL="$1"
+
+    REV=$(get_rev "$TOPLEVEL" "$1")
+    DESCRIPTION="${cfg.bootEntry}"
+
+    # ── Install kernel & initrd ───────────────────────────────────────────────
+
+    mkdir -p ${cfg.bootDir}
+
+    echo "==> Installing kernel and initrd (timestamp: $TIMESTAMP)"
+    install -m 0644 "$KERNEL" "$KERNEL_PATH"
+    install -m 0644 "$INITRD" "$INITRD_PATH"
+
+    # ── Secure Boot ───────────────────────────────────────────────────────────
+
+    if [ "${lib.boolToString cfg.secureBoot.enable}" = "true" ]; then
+      if [ -d ${cfg.secureBoot.keyLocation} ]; then
+        echo "==> sbctl: signing kernel"
+        ${cfg.secureBoot.sbctl}/bin/sbctl sign "$KERNEL_PATH" || \
+          echo "WARNING: sbctl signing failed, but continuing (Secure Boot may not work)"
+      fi
+    fi
+
+    # ── Create NVRAM entry ────────────────────────────────────────────────────
+
+    echo "==> Creating new primary entry: $DESCRIPTION (timestamp $TIMESTAMP)"
+    ESP_REL_DIR_WIN=$(${pkgs.coreutils}/bin/tr '/' '\\' <<< "${ESP_REL_DIR}")
+    ESP_KERNEL_PATH="\\''${ESP_REL_DIR_WIN}\\kernel-$TIMESTAMP.efi"
+    ESP_INITRD_PATH="\\''${ESP_REL_DIR_WIN}\\initrd-$TIMESTAMP"
+    NEW_ID=$("$EFISTUBMGR" create "${cfg.efiMountPoint}" \
+      '\EFI\finix\kernel-'"$TIMESTAMP"'.efi' \
+      "$DESCRIPTION" \
+      "initrd=$ESP_INITRD_PATH init=$INIT $PARAMS" \
+      --timestamp "$TIMESTAMP")
+
+    echo "==> Created Boot$NEW_ID"
+
+    # ── Keep newest generations ───────────────────────────────────────────────
+
+    mapfile -t GENERATIONS < <("$EFISTUBMGR" list)
+    echo "==> ''${#GENERATIONS[@]} finix generation(s) in NVRAM"
+
+    KEEP_TIMESTAMPS=()
+    for line in "''${GENERATIONS[@]:0:${toString cfg.maxGenerations}}"; do
+      KEEP_TIMESTAMPS+=(
+        "$(${pkgs.gawk}/bin/awk '{print $2}' <<<"$line")"
+      )
+    done
+
+    declare -A PRUNE_IDS
+
+    if [ "''${#GENERATIONS[@]}" -gt "${toString cfg.maxGenerations}" ]; then
+      for line in "''${GENERATIONS[@]:${toString cfg.maxGenerations}}"; do
+        id=$(${pkgs.gawk}/bin/awk '{print $1}' <<<"$line")
+        ts=$(${pkgs.gawk}/bin/awk '{print $2}' <<<"$line")
+
+        "$EFISTUBMGR" delete "$id"
+        PRUNE_IDS["$ts"]="$id"
+      done
+    fi
+
+    # ── Remove orphaned ESP files ─────────────────────────────────────────────
+
+    ORPHAN_TIMESTAMPS=()
+
+    for f in "${cfg.bootDir}"/kernel-*.efi "${cfg.bootDir}"/initrd-*; do
+      [ -e "$f" ] || continue
+
+      base=$(basename "$f")
+      file_ts="''${base#*-}"
+      file_ts="''${file_ts%.efi}"
+
+      if ! is_kept_timestamp "$file_ts" &&
+         ! is_seen_timestamp "$file_ts"; then
+        ORPHAN_TIMESTAMPS+=("$file_ts")
+      fi
+    done
+
+    for ts in "''${ORPHAN_TIMESTAMPS[@]}"; do
+      if [ -n "''${PRUNE_IDS[$ts]:-}" ]; then
+        echo "==> Removing orphaned ESP files kernel-$ts.efi + initrd-$ts" \
+          "(ts $ts, removed matching Boot''${PRUNE_IDS[$ts]} NVRAM entry)"
+      else
+        echo "==> Removing orphaned ESP files kernel-$ts.efi + initrd-$ts" \
+          "(ts $ts, no matching NVRAM entry)"
+      fi
+
+      rm -f "${cfg.bootDir}/kernel-$ts.efi" "${cfg.bootDir}/initrd-$ts"
+    done
+
+    echo "==> EFISTUB setup complete"
+  '';
 in
 {
-  options.programs.nh = {
-    enable = lib.mkEnableOption "nh, yet another Nix CLI helper";
-
-    package = lib.mkPackageOption pkgs "nh" { };
-
-    flake = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
+  meta.maintainers = with lib.maintainers; [
+    Z4il
+  ];
+  options.programs.efistubmgr = {
+    enable = lib.mkEnableOption "Minimal EFISTUB manager written in Rust.";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./package.nix { };
+      defaultText = lib.literalExpression "pkgs.callPackage ./package.nix {}";
       description = ''
-        The string that will be used for the `NH_FLAKE` environment variable.
-
-        `NH_FLAKE` is used by nh as the default flake for performing actions, such as
-        `nh os switch`. This behaviour can be overriden per-command with environment
-        variables that will take priority.
-
-        - `NH_OS_FLAKE`: will take priority for `nh os` commands.
-        - `NH_HOME_FLAKE`: will take priority for `nh home` commands.
-        - `NH_DARWIN_FLAKE`: will take priority for `nh darwin` commands.
-
-        The formerly valid `FLAKE` is now deprecated by nh, and will cause hard errors
-        in future releases if `NH_FLAKE` is not set.
-
-        `NH_FLAKE` can point to either a folder containing a flake, or to an outside repository containing the flake.
+        The package to use for efistubmgr.
       '';
     };
-
-    clean = {
-      enable = lib.mkEnableOption "periodic garbage collection with nh clean all";
-
-      dates = lib.mkOption {
-        type = lib.types.singleLineStr;
-        default = "weekly";
+    efiMountPoint = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.boot.loader.efi.efiSysMountPoint}";
+      description = ''
+        Where the EFI System Partition is mounted.
+      '';
+    };
+    maxGenerations = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 3;
+      description = ''
+        Number of generations (positive and >0) to show in UEFI boot picker/to keep in NVRAM.
+      '';
+    };
+    secureBoot = {
+      enable = lib.mkEnableOption "Whether to enable secure boot or not.";
+      keyLocation = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/sbctl/keys";
         description = ''
-          How often `nh clean` is performed. Accepts either a standard {manpage}`crontab(5)` expression
-          or one of: `hourly`, `daily`, `weekly`, `monthly`, or `yearly`.
-
-          If a standard {manpage}`crontab(5)` expression is provided this value will be passed directly
-          to the `scheduler` implementation and execute exactly as specified.
-
-          If one of the special values, `hourly`, `daily`, `monthly`, `weekly`, or `yearly`, is provided then the
-          underlying `scheduler` implementation will use its features to decide when best to run.
+          Location of the keys used for secureboot signing, bring your own.
         '';
       };
+      sbctl = lib.mkPackageOption pkgs "sbctl" { };
+    };
+    bootDir = lib.mkOption {
+      type = lib.types.str;
+      default = "${cfg.efiMountPoint}/EFI/finix";
+      description = ''
+        Where to save the kerenl stubs and initrd
+      '';
+    };
+    bootEntry = lib.mkOption {
+      type = lib.types.str;
+      default = ''$LABEL''${REV:+ $REV} * $(${pkgs.coreutils}/bin/date -d "@$TIMESTAMP" '+%Y-%m-%d %H:%M:%S %Z')'';
+      description = "How each generation appears in the UEFI boot picker, REV and LABEL are provided as is in the install script. Non ASCII characters may stop it from appearing in the Boot Options";
+    };
 
-      extraArgs = lib.mkOption {
-        type = lib.types.singleLineStr;
-        default = "";
-        example = "--keep 5 --keep-since 3d";
-        description = ''
-          Options given to nh clean when the service is run automatically.
-
-          See `nh clean all --help` for more information.
-        '';
-      };
+    bootSpec = lib.mkOption {
+      type = lib.types.str;
+      default = "$1/boot.json";
+      description = ''
+        Path to a boot specification, best to leave as default unless you know what you are doing
+      '';
     };
   };
-
   config = {
-    assertions = [
-      {
-        assertion = (cfg.flake != null) -> !(lib.hasSuffix ".nix" cfg.flake);
-        message = "nh.flake must be a directory, or valid repository, not a nix file.";
-      }
-    ];
-
     environment = lib.mkIf cfg.enable {
-      systemPackages = [ cfg.package ];
-      variables = lib.mkIf (cfg.flake != null) {
-        NH_FLAKE = cfg.flake;
-      };
+      systemPackages = [
+        cfg.package
+        pkgs.jq
+      ];
     };
-
-    providers.scheduler.tasks.nh-clean = lib.mkIf cfg.clean.enable {
-      command = "${lib.getExe cfg.package} clean all ${cfg.clean.extraArgs}";
-      interval = cfg.clean.dates;
+    boot.loader.script = {
+      enable = true;
+      installHook = efistubHook;
     };
   };
 }

--- a/modules/programs/nh/default.nix
+++ b/modules/programs/nh/default.nix
@@ -71,7 +71,7 @@ in
       };
     };
 
-    providers.scheduler = {
+    providers.scheduler = lib.mkIf cfg.clean.enable {
       backend = lib.mkDefault "cron";
       tasks.nh-clean = {
         command = "${lib.getExe cfg.package} clean all ${cfg.clean.extraArgs}";

--- a/modules/programs/nh/default.nix
+++ b/modules/programs/nh/default.nix
@@ -29,6 +29,8 @@ in
 
         The formerly valid `FLAKE` is now deprecated by nh, and will cause hard errors
         in future releases if `NH_FLAKE` is not set.
+
+        `NH_FLAKE` can point to either a folder containing a flake, or to an outside repository containing the flake
       '';
     };
 
@@ -67,7 +69,7 @@ in
     assertions = [
       {
         assertion = (cfg.flake != null) -> !(lib.hasSuffix ".nix" cfg.flake);
-        message = "nh.flake must be a directory, not a nix file";
+        message = "nh.flake must be a directory, or valid repository, not a nix file";
       }
     ];
 

--- a/modules/programs/nh/default.nix
+++ b/modules/programs/nh/default.nix
@@ -74,7 +74,7 @@ in
     providers.scheduler = {
       backend = lib.mkDefault "cron";
       tasks.nh-clean = {
-        command = "exec ${lib.getExe cfg.package} clean all ${cfg.clean.extraArgs}";
+        command = "${lib.getExe cfg.package} clean all ${cfg.clean.extraArgs}";
         interval = cfg.clean.dates;  
       };
     };

--- a/modules/programs/nh/default.nix
+++ b/modules/programs/nh/default.nix
@@ -39,7 +39,14 @@ in
         type = lib.types.singleLineStr;
         default = "weekly";
         description = ''
-          How often cleanup is performed. Passed to providers.scheduler
+          How often `nh clean` is performed. Accepts either a standard {manpage}`crontab(5)` expression
+          or one of: `hourly`, `daily`, `weekly`, `monthly`, or `yearly`.
+
+          If a standard {manpage}`crontab(5)` expression is provided this value will be passed directly
+          to the `scheduler` implementation and execute exactly as specified.
+
+          If one of the special values, `hourly`, `daily`, `monthly`, `weekly`, or `yearly`, is provided then the
+          underlying `scheduler` implementation will use its features to decide when best to run.
         '';
       };
 

--- a/modules/programs/nh/default.nix
+++ b/modules/programs/nh/default.nix
@@ -1,241 +1,88 @@
 {
-  pkgs,
-  lib,
   config,
+  lib,
+  pkgs,
   ...
 }:
 let
-  cfg = config.programs.efistubmgr;
-  ESP_REL_DIR = "${lib.removePrefix "/" (lib.removePrefix cfg.efiMountPoint cfg.bootDir)}";
-  efistubHook = pkgs.writeShellScript "efistub-install" ''
-    set -euo pipefail
-
-    # ── Paths & metadata ──────────────────────────────────────────────────────
-
-    EFISTUBMGR="${cfg.package}/bin/efistubmgr"
-
-    TIMESTAMP=$(${pkgs.coreutils}/bin/date +%s)
-    KERNEL_PATH="${cfg.bootDir}/kernel-$TIMESTAMP.efi"
-    INITRD_PATH="${cfg.bootDir}/initrd-$TIMESTAMP"
-
-    # ── Helpers ───────────────────────────────────────────────────────────────
-
-    get_rev() {
-      local target="$1"
-      local path="$2"
-      local link
-
-      for link in /nix/var/nix/profiles/system-*-link; do
-        [ -e "$link" ] || continue
-
-        case "$(readlink "$link")" in
-          "$target"|"$path")
-            printf '%s\n' "$link" |
-              ${pkgs.gnugrep}/bin/grep -oE 'system-[0-9]+-link' |
-              ${pkgs.gnugrep}/bin/grep -oE '[0-9]+' |
-              ${pkgs.gawk}/bin/awk '{print "rev. " $1}'
-            return
-            ;;
-        esac
-      done
-    }
-
-    is_kept_timestamp() {
-      local needle="$1"
-
-      for ts in "''${KEEP_TIMESTAMPS[@]}"; do
-        [ "$ts" = "$needle" ] && return 0
-      done
-
-      return 1
-    }
-
-    is_seen_timestamp() {
-      local needle="$1"
-
-      for ts in "''${ORPHAN_TIMESTAMPS[@]}"; do
-        [ "$ts" = "$needle" ] && return 0
-      done
-
-      return 1
-    }
-
-    # ── Validate & read bootspec ──────────────────────────────────────────────
-
-    [ -r ${cfg.bootSpec} ] ||
-      { echo "ERROR: boot.json not found at ${cfg.bootSpec}"; exit 1; }
-
-    KERNEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".kernel' "${cfg.bootSpec}")
-    INITRD=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".initrd' "${cfg.bootSpec}")
-    INIT=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".init' "${cfg.bootSpec}")
-    PARAMS=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".kernelParams | join(" ")' "${cfg.bootSpec}")
-    LABEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".label // empty' "${cfg.bootSpec}")
-    TOPLEVEL=$(${pkgs.jq}/bin/jq -r '."org.nixos.bootspec.v1".toplevel // empty' "${cfg.bootSpec}")
-
-    [ -z "$LABEL" ] || [ "$LABEL" = "null" ] && LABEL="Finix"
-    [ -z "$TOPLEVEL" ] && TOPLEVEL="$1"
-
-    REV=$(get_rev "$TOPLEVEL" "$1")
-    DESCRIPTION="${cfg.bootEntry}"
-
-    # ── Install kernel & initrd ───────────────────────────────────────────────
-
-    mkdir -p ${cfg.bootDir}
-
-    echo "==> Installing kernel and initrd (timestamp: $TIMESTAMP)"
-    install -m 0644 "$KERNEL" "$KERNEL_PATH"
-    install -m 0644 "$INITRD" "$INITRD_PATH"
-
-    # ── Secure Boot ───────────────────────────────────────────────────────────
-
-    if [ "${lib.boolToString cfg.secureBoot.enable}" = "true" ]; then
-      if [ -d ${cfg.secureBoot.keyLocation} ]; then
-        echo "==> sbctl: signing kernel"
-        ${cfg.secureBoot.sbctl}/bin/sbctl sign "$KERNEL_PATH" || \
-          echo "WARNING: sbctl signing failed, but continuing (Secure Boot may not work)"
-      fi
-    fi
-
-    # ── Create NVRAM entry ────────────────────────────────────────────────────
-
-    echo "==> Creating new primary entry: $DESCRIPTION (timestamp $TIMESTAMP)"
-    ESP_REL_DIR_WIN=$(${pkgs.coreutils}/bin/tr '/' '\\' <<< "${ESP_REL_DIR}")
-    ESP_KERNEL_PATH="\\''${ESP_REL_DIR_WIN}\\kernel-$TIMESTAMP.efi"
-    ESP_INITRD_PATH="\\''${ESP_REL_DIR_WIN}\\initrd-$TIMESTAMP"
-    NEW_ID=$("$EFISTUBMGR" create "${cfg.efiMountPoint}" \
-      '\EFI\finix\kernel-'"$TIMESTAMP"'.efi' \
-      "$DESCRIPTION" \
-      "initrd=$ESP_INITRD_PATH init=$INIT $PARAMS" \
-      --timestamp "$TIMESTAMP")
-
-    echo "==> Created Boot$NEW_ID"
-
-    # ── Keep newest generations ───────────────────────────────────────────────
-
-    mapfile -t GENERATIONS < <("$EFISTUBMGR" list)
-    echo "==> ''${#GENERATIONS[@]} finix generation(s) in NVRAM"
-
-    KEEP_TIMESTAMPS=()
-    for line in "''${GENERATIONS[@]:0:${toString cfg.maxGenerations}}"; do
-      KEEP_TIMESTAMPS+=(
-        "$(${pkgs.gawk}/bin/awk '{print $2}' <<<"$line")"
-      )
-    done
-
-    declare -A PRUNE_IDS
-
-    if [ "''${#GENERATIONS[@]}" -gt "${toString cfg.maxGenerations}" ]; then
-      for line in "''${GENERATIONS[@]:${toString cfg.maxGenerations}}"; do
-        id=$(${pkgs.gawk}/bin/awk '{print $1}' <<<"$line")
-        ts=$(${pkgs.gawk}/bin/awk '{print $2}' <<<"$line")
-
-        "$EFISTUBMGR" delete "$id"
-        PRUNE_IDS["$ts"]="$id"
-      done
-    fi
-
-    # ── Remove orphaned ESP files ─────────────────────────────────────────────
-
-    ORPHAN_TIMESTAMPS=()
-
-    for f in "${cfg.bootDir}"/kernel-*.efi "${cfg.bootDir}"/initrd-*; do
-      [ -e "$f" ] || continue
-
-      base=$(basename "$f")
-      file_ts="''${base#*-}"
-      file_ts="''${file_ts%.efi}"
-
-      if ! is_kept_timestamp "$file_ts" &&
-         ! is_seen_timestamp "$file_ts"; then
-        ORPHAN_TIMESTAMPS+=("$file_ts")
-      fi
-    done
-
-    for ts in "''${ORPHAN_TIMESTAMPS[@]}"; do
-      if [ -n "''${PRUNE_IDS[$ts]:-}" ]; then
-        echo "==> Removing orphaned ESP files kernel-$ts.efi + initrd-$ts" \
-          "(ts $ts, removed matching Boot''${PRUNE_IDS[$ts]} NVRAM entry)"
-      else
-        echo "==> Removing orphaned ESP files kernel-$ts.efi + initrd-$ts" \
-          "(ts $ts, no matching NVRAM entry)"
-      fi
-
-      rm -f "${cfg.bootDir}/kernel-$ts.efi" "${cfg.bootDir}/initrd-$ts"
-    done
-
-    echo "==> EFISTUB setup complete"
-  '';
+  cfg = config.programs.nh;
 in
 {
-  meta.maintainers = with lib.maintainers; [
-    Z4il
-  ];
-  options.programs.efistubmgr = {
-    enable = lib.mkEnableOption "Minimal EFISTUB manager written in Rust.";
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.callPackage ./package.nix { };
-      defaultText = lib.literalExpression "pkgs.callPackage ./package.nix {}";
+  options.programs.nh = {
+    enable = lib.mkEnableOption "nh, yet another Nix CLI helper";
+
+    package = lib.mkPackageOption pkgs "nh" { };
+
+    flake = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
       description = ''
-        The package to use for efistubmgr.
+        The string that will be used for the `NH_FLAKE` environment variable.
+
+        `NH_FLAKE` is used by nh as the default flake for performing actions, such as
+        `nh os switch`. This behaviour can be overriden per-command with environment
+        variables that will take priority.
+
+        - `NH_OS_FLAKE`: will take priority for `nh os` commands.
+        - `NH_HOME_FLAKE`: will take priority for `nh home` commands.
+        - `NH_DARWIN_FLAKE`: will take priority for `nh darwin` commands.
+
+        The formerly valid `FLAKE` is now deprecated by nh, and will cause hard errors
+        in future releases if `NH_FLAKE` is not set.
+
+        `NH_FLAKE` can point to either a folder containing a flake, or to an outside repository containing the flake.
       '';
-    };
-    efiMountPoint = lib.mkOption {
-      type = lib.types.str;
-      default = "${config.boot.loader.efi.efiSysMountPoint}";
-      description = ''
-        Where the EFI System Partition is mounted.
-      '';
-    };
-    maxGenerations = lib.mkOption {
-      type = lib.types.ints.positive;
-      default = 3;
-      description = ''
-        Number of generations (positive and >0) to show in UEFI boot picker/to keep in NVRAM.
-      '';
-    };
-    secureBoot = {
-      enable = lib.mkEnableOption "Whether to enable secure boot or not.";
-      keyLocation = lib.mkOption {
-        type = lib.types.str;
-        default = "/var/lib/sbctl/keys";
-        description = ''
-          Location of the keys used for secureboot signing, bring your own.
-        '';
-      };
-      sbctl = lib.mkPackageOption pkgs "sbctl" { };
-    };
-    bootDir = lib.mkOption {
-      type = lib.types.str;
-      default = "${cfg.efiMountPoint}/EFI/finix";
-      description = ''
-        Where to save the kerenl stubs and initrd
-      '';
-    };
-    bootEntry = lib.mkOption {
-      type = lib.types.str;
-      default = ''$LABEL''${REV:+ $REV} * $(${pkgs.coreutils}/bin/date -d "@$TIMESTAMP" '+%Y-%m-%d %H:%M:%S %Z')'';
-      description = "How each generation appears in the UEFI boot picker, REV and LABEL are provided as is in the install script. Non ASCII characters may stop it from appearing in the Boot Options";
     };
 
-    bootSpec = lib.mkOption {
-      type = lib.types.str;
-      default = "$1/boot.json";
-      description = ''
-        Path to a boot specification, best to leave as default unless you know what you are doing
-      '';
+    clean = {
+      enable = lib.mkEnableOption "periodic garbage collection with nh clean all";
+
+      dates = lib.mkOption {
+        type = lib.types.singleLineStr;
+        default = "weekly";
+        description = ''
+          How often `nh clean` is performed. Accepts either a standard {manpage}`crontab(5)` expression
+          or one of: `hourly`, `daily`, `weekly`, `monthly`, or `yearly`.
+
+          If a standard {manpage}`crontab(5)` expression is provided this value will be passed directly
+          to the `scheduler` implementation and execute exactly as specified.
+
+          If one of the special values, `hourly`, `daily`, `monthly`, `weekly`, or `yearly`, is provided then the
+          underlying `scheduler` implementation will use its features to decide when best to run.
+        '';
+      };
+
+      extraArgs = lib.mkOption {
+        type = lib.types.singleLineStr;
+        default = "";
+        example = "--keep 5 --keep-since 3d";
+        description = ''
+          Options given to nh clean when the service is run automatically.
+
+          See `nh clean all --help` for more information.
+        '';
+      };
     };
   };
+
   config = {
+    assertions = [
+      {
+        assertion = (cfg.flake != null) -> !(lib.hasSuffix ".nix" cfg.flake);
+        message = "nh.flake must be a directory, or valid repository, not a nix file.";
+      }
+    ];
+
     environment = lib.mkIf cfg.enable {
-      systemPackages = [
-        cfg.package
-        pkgs.jq
-      ];
+      systemPackages = [ cfg.package ];
+      variables = lib.mkIf (cfg.flake != null) {
+        NH_FLAKE = cfg.flake;
+      };
     };
-    boot.loader.script = {
-      enable = true;
-      installHook = efistubHook;
+
+    providers.scheduler.tasks.nh-clean = lib.mkIf cfg.clean.enable {
+      command = "${lib.getExe cfg.package} clean all ${cfg.clean.extraArgs}";
+      interval = cfg.clean.dates;
     };
   };
 }

--- a/modules/programs/nh/default.nix
+++ b/modules/programs/nh/default.nix
@@ -30,7 +30,7 @@ in
         The formerly valid `FLAKE` is now deprecated by nh, and will cause hard errors
         in future releases if `NH_FLAKE` is not set.
 
-        `NH_FLAKE` can point to either a folder containing a flake, or to an outside repository containing the flake
+        `NH_FLAKE` can point to either a folder containing a flake, or to an outside repository containing the flake.
       '';
     };
 
@@ -69,7 +69,7 @@ in
     assertions = [
       {
         assertion = (cfg.flake != null) -> !(lib.hasSuffix ".nix" cfg.flake);
-        message = "nh.flake must be a directory, or valid repository, not a nix file";
+        message = "nh.flake must be a directory, or valid repository, not a nix file.";
       }
     ];
 
@@ -80,12 +80,9 @@ in
       };
     };
 
-    providers.scheduler = lib.mkIf cfg.clean.enable {
-      backend = lib.mkDefault "cron";
-      tasks.nh-clean = {
-        command = "${lib.getExe cfg.package} clean all ${cfg.clean.extraArgs}";
-        interval = cfg.clean.dates;  
-      };
+    providers.scheduler.tasks.nh-clean = lib.mkIf cfg.clean.enable {
+      command = "${lib.getExe cfg.package} clean all ${cfg.clean.extraArgs}";
+      interval = cfg.clean.dates;
     };
   };
 }


### PR DESCRIPTION
The nh module is largely the same as the one in nixpkgs except it removes the systemd.timers dep in lue of cronjobs, defaulting to cron as the backend.

Efistubmgr is a new module for the program made by FixeQD which manages kernel stubs letting you boot without any fully-fledged boot loader (other than your UEFI), it adds several options primarily secureBoot, enable, and maxGenerations