### PR TITLE
Remove steam-run from the steam module

### DIFF
--- a/modules/programs/steam/README.md
+++ b/modules/programs/steam/README.md
@@ -4,6 +4,5 @@ Community module for `steam`. Currently sets up the following:
 
 - video drivers
 - `steam` package
-- steam-run (libraries required for steam to run on a non-standard LFH system)
 
-Also allows for extra configuration like environment variables, package overrides, etc. 
+Also allows for extra configuration like environment variables, package overrides, etc.

--- a/modules/programs/steam/default.nix
+++ b/modules/programs/steam/default.nix
@@ -198,10 +198,7 @@ in
 
     services.dbus.enable = true;
 
-    environment.systemPackages = [
-      cfg.package
-      cfg.package.run
-    ]
+    environment.systemPackages = [ cfg.package ]
     ++ lib.optionals cfg.gamescopeSession.enable [
       steam-gamescope
       (lib.hiPrio gamescopeSessionFile)

--- a/modules/programs/steam/default.nix
+++ b/modules/programs/steam/default.nix
@@ -198,7 +198,9 @@ in
 
     services.dbus.enable = true;
 
-    environment.systemPackages = [ cfg.package ]
+    environment.systemPackages = [
+      cfg.package
+    ]
     ++ lib.optionals cfg.gamescopeSession.enable [
       steam-gamescope
       (lib.hiPrio gamescopeSessionFile)


### PR DESCRIPTION
In testing of 2 linux games and 2 proton games removing it caused no issues. If issues arise the user can add it under `programs.steam.extraPackages` for the same effect.